### PR TITLE
blocks nil channel

### DIFF
--- a/goflow.go
+++ b/goflow.go
@@ -72,8 +72,10 @@ func (flw *Flow) do() (map[string]interface{}, error) {
 	var err error
 	res := make(map[string]interface{}, len(flw.funcs))
 
-	for name, f := range flw.funcs {
+	for _, f := range flw.funcs{
 		f.Init()
+	}
+	for name, f := range flw.funcs {
 		go func(name string, fs *flowStruct) {
 			defer func() { fs.Close() }()
 			results := make(map[string]interface{}, len(fs.Deps))


### PR DESCRIPTION
Sometimes, child function waits for receiving result of parent function in line. 85 before parent function is initialized.
So, all functions should be  initialized before running go-routine asynchronously.